### PR TITLE
se agrega un caracter para poder graficar

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -70,7 +70,7 @@ void configure_usart(void)
 void usart_send_labeled_value(const char *label, uint16_t value)
 {
     char buffer[20];
-    int len = snprintf(buffer, sizeof(buffer), "%s:%u\n", label, value); // Formato: "Etiqueta:Valor"
+    int len = snprintf(buffer, sizeof(buffer), ">%s:%u\n", label, value); // Formato: "Etiqueta:Valor"
     for (int i = 0; i < len; i++)
     {
         usart_send_blocking(USART1, buffer[i]); // Envía cada carácter


### PR DESCRIPTION
Al agregar este caracter (>) en las impresiones de los datos recibidos por UART, podemos gráficar los valores obtenidos.
Lo importante es la siguiente estructura: ">%s:%u\n"
Ejemplo de un caso particular:
![image](https://github.com/user-attachments/assets/2a482d10-d0e4-481e-8740-37d77ac41e7c)
